### PR TITLE
Added feature to fetch s3 credential from aws provider chain

### DIFF
--- a/parquet_s3_fdw.h
+++ b/parquet_s3_fdw.h
@@ -51,6 +51,8 @@ typedef struct parquet_s3_server_opt
 	bool		use_minio;		/* Connect to MinIO instead of Amazon S3. */
 	bool		keep_connections;	/* setting value of keep_connections
 									 * server option */
+	bool        use_credential_provider; /* Retrieve AWS credentials using
+	                                      * AWS Credential providers */
 	char	   *region;			/* AWS region to connect to */
 	char	   *endpoint;		/* Address and port to connect to */
 }			parquet_s3_server_opt;
@@ -71,6 +73,7 @@ int	ExecForeignDDL(Oid serverOid,
 /* Option name for CREATE FOREIGN SERVER. */
 #define SERVER_OPTION_USE_MINIO "use_minio"
 #define SERVER_OPTION_KEEP_CONNECTIONS "keep_connections"
+#define SERVER_OPTION_USE_CREDENTIAL_PROVIDER "use_credential_provider"
 #define SERVER_OPTION_REGION "region"
 #define SERVER_OPTION_ENDPOINT "endpoint"
 

--- a/parquet_s3_fdw.hpp
+++ b/parquet_s3_fdw.hpp
@@ -58,7 +58,7 @@ typedef enum FileLocation_t
 /*
  * We would like to cache FileReader. When creating new hash entry,
  * the memory of entry is allocated by PostgreSQL core. But FileReader is
- * a unique_ptr. In order to initialize it in parquet_s3_fdw, we define 
+ * a unique_ptr. In order to initialize it in parquet_s3_fdw, we define
  * FileReaderCache class and the cache entry has the pointer of this class.
  */
 class FileReaderCache
@@ -84,7 +84,7 @@ extern List *extract_parquet_fields(const char *path, const char *dirname, Aws::
 extern char *create_foreign_table_query(const char *tablename, const char *schemaname, const char *servername,
                                          char **paths, int npaths, List *fields, List *options);
 
-extern Aws::S3::S3Client *parquetGetConnection(UserMapping *user, bool use_minio);
+extern Aws::S3::S3Client *parquetGetConnection(UserMapping *user, parquet_s3_server_opt* option);
 extern Aws::S3::S3Client *parquetGetConnectionByTableid(Oid foreigntableid, Oid userid);
 extern void parquetReleaseConnection(Aws::S3::S3Client *conn);
 extern List* parquetGetS3ObjectList(Aws::S3::S3Client *s3_cli, const char *s3path);

--- a/parquet_s3_fdw_server_option.c
+++ b/parquet_s3_fdw_server_option.c
@@ -33,7 +33,8 @@ bool
 parquet_s3_is_valid_server_option(DefElem *def)
 {
 	if (strcmp(def->defname, SERVER_OPTION_USE_MINIO) == 0 ||
-		strcmp(def->defname, SERVER_OPTION_KEEP_CONNECTIONS) == 0)
+		strcmp(def->defname, SERVER_OPTION_KEEP_CONNECTIONS) == 0 ||
+		strcmp(def->defname, SERVER_OPTION_USE_CREDENTIAL_PROVIDER) == 0)
 	{
 		/* Check that bool value is valid */
 		bool		check_bool_valid;
@@ -71,6 +72,8 @@ parquet_s3_extract_options(List *options, parquet_s3_server_opt * opt)
 			opt->use_minio = defGetBoolean(def);
 		else if (strcmp(def->defname, SERVER_OPTION_KEEP_CONNECTIONS) == 0)
 			opt->keep_connections = defGetBoolean(def);
+		else if (strcmp(def->defname, SERVER_OPTION_USE_CREDENTIAL_PROVIDER) == 0)
+			opt->use_credential_provider = defGetBoolean(def);
 		else if (strcmp(def->defname, SERVER_OPTION_REGION) == 0)
 			opt->region = defGetString(def);
 		else if (strcmp(def->defname, SERVER_OPTION_ENDPOINT) == 0)
@@ -98,6 +101,7 @@ parquet_s3_get_options(Oid foreignoid)
 	opt->use_minio = false;
 	/* By default, all the connections to any foreign servers are kept open. */
 	opt->keep_connections = true;
+	opt->use_credential_provider = false;
 	opt->region = "ap-northeast-1";
 	opt->endpoint = "127.0.0.1:9000";
 
@@ -147,6 +151,7 @@ parquet_s3_get_server_options(Oid serverid)
 	opt->use_minio = false;
 	/* By default, all the connections to any foreign servers are kept open. */
 	opt->keep_connections = true;
+	opt->use_credential_provider = false;
 	opt->region = "ap-northeast-1";
 	opt->endpoint = "127.0.0.1:9000";
 

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -989,7 +989,7 @@ extract_rowgroups_list(const char *filename,
         }  /* loop over rowgroups */
     }
     catch(const std::exception& e) {
-        error = e.what();      
+        error = e.what();
     }
     if (!error.empty()) {
         if (reader_entry)
@@ -2540,7 +2540,7 @@ parquetAcquireSampleRowsFunc(Relation relation, int /* elevel */,
         slcols.insert(std::string(strVal(rcol)));
     }
 
-    festate = create_parquet_execution_state(RT_MULTI, reader_cxt, 
+    festate = create_parquet_execution_state(RT_MULTI, reader_cxt,
                                              fdw_private.dirname,
                                              fdw_private.s3client,
                                              tupleDesc,
@@ -2753,7 +2753,7 @@ parquetIsForeignScanParallelSafe(PlannerInfo * /* root */,
                                  RelOptInfo *rel,
                                  RangeTblEntry * /* rte */)
 {
-    /* Plan nodes that reference a correlated SubPlan is always parallel restricted. 
+    /* Plan nodes that reference a correlated SubPlan is always parallel restricted.
      * Therefore, return false when there is lateral join.
      */
     if (rel->lateral_relids)
@@ -4329,6 +4329,7 @@ int ExecForeignDDL(Oid serverOid,
     table = GetForeignTable(RelationGetRelid(rel));
     user = GetUserMapping(GetUserId(), serverOid);
 
+    parquet_s3_server_opt *options = parquet_s3_get_options(serverOid);
     foreach(lc, server->options)
     {
         DefElem    *def = (DefElem *) lfirst(lc);
@@ -4351,7 +4352,7 @@ int ExecForeignDDL(Oid serverOid,
     }
 
     if (IS_S3_PATH(dirname) || parquetIsS3Filenames(filenames))
-        s3_client = parquetGetConnection(user, use_minio);
+        s3_client = parquetGetConnection(user, options);
     else
         s3_client = NULL;
 


### PR DESCRIPTION
Introduced a new **_boolean_** server option **"use_credential_provider"**, by default its set to _FALSE_. In case of _TRUE_, AWS credentials will be fetched through DefaultAWSCredentialProviderChain, and it follows the following credential probe order.

```
Default Credential Provider Chain

The default credential provider chain does the following:

    Checks your environment variables for AWS Credentials
    Checks your $HOME/.aws/credentials file for a profile and credentials
    Contacts and logs in to a trusted identity provider (Cognito, Login with Amazon, Facebook, Google). The sdk looks for the login information to these providers either on the environment variables: AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE, AWS_ROLE_SESSION_NAME. Or on a profile in your $HOME/.aws/credentials.
    Checks for an external method set as part of a profile on $HOME/.aws/config to generate or look up credentials that isn't directly supported by AWS.
    Contacts the ECS TaskRoleCredentialsProvider service to request credentials if Environment variable AWS_CONTAINER_CREDENTIALS_RELATIVE_URI has been set.
    Contacts the EC2MetadataInstanceProfileCredentialsProvider service to request credentials if AWS_EC2_METADATA_DISABLED is NOT set to ON.`
```